### PR TITLE
Merge fritz-specific content into this fork's master

### DIFF
--- a/config.defaults.yaml
+++ b/config.defaults.yaml
@@ -6,7 +6,7 @@ kowalski:
     host: "0.0.0.0"
     port: "4000"
     admin_username: "admin"
-    # fixme: use a strong password
+    # fixme: use ''.join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(32))
     admin_password: "admin"
     # fixme: use ''.join(secrets.choice(string.ascii_lowercase + string.digits) for _ in range(32))
     SECRET_KEY: "abc0123"
@@ -31,7 +31,7 @@ kowalski:
   kafka:
     default.topic.config:
       auto.offset.reset: "earliest"
-    group: "kowalski"
+    group: "fritz"
 
     bootstrap.servers: "192.168.0.64:9092,192.168.0.65:9092,192.168.0.66:9092"
     zookeeper: "192.168.0.64:2181"
@@ -40,7 +40,7 @@ kowalski:
 
   database:
     max_pool_size: 200
-    host: "mongo"
+    host: "kowalski_mongo_1"
     port: 27017
     # if not null, must be same as in entrypoint of mongo container
     replica_set: "rs0"
@@ -69,129 +69,158 @@ kowalski:
       ZTF_alerts:
         - name: radec_candid
           fields:
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "candid", -1 ]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["candid", -1]
           unique: false
         - name: radec_objectId
           fields:
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "objectId", -1 ]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["objectId", -1]
           unique: false
         - name: jd_radec_candid
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "candid", -1 ]
+            - ["candidate.jd", 1]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["candid", -1]
           unique: false
         - name: jd_radec_objectId
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "objectId", -1 ]
+            - ["candidate.jd", 1]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["objectId", -1]
           unique: false
         - name: objectId
           fields:
-            - [ "objectId", -1 ]
+            - ["objectId", -1]
           unique: false
         - name: candid
           fields:
-            - [ "candid", -1 ]
+            - ["candid", -1]
           unique: true
         - name: pid
           fields:
-            - [ "candidate.pid", 1 ]
+            - ["candidate.pid", 1]
           unique: false
         - name: objectId_pid
           fields:
-            - [ "objectId", -1 ]
-            - [ "candidate.pid", 1 ]
+            - ["objectId", -1]
+            - ["candidate.pid", 1]
           unique: false
         - name: pdiffimfilename
           fields:
-            - [ "candidate.pdiffimfilename", 1 ]
+            - ["candidate.pdiffimfilename", 1]
           unique: false
         - name: jd_programid_programpi
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "candidate.programid", 1 ]
-            - [ "candidate.programpi", 1 ]
+            - ["candidate.jd", 1]
+            - ["candidate.programid", 1]
+            - ["candidate.programpi", 1]
           unique: false
         - name: jd_braai_candid
           fields:
-            - [ "candidate.jd", -1 ]
-            - [ "classifications.braai", -1 ]
-            - [ "candid", -1 ]
+            - ["candidate.jd", -1]
+            - ["classifications.braai", -1]
+            - ["candid", -1]
           unique: false
         - name: jd_drb_candid
           fields:
-            - [ "candidate.jd", -1 ]
-            - [ "candidate.drb", -1 ]
-            - [ "candid", -1 ]
+            - ["candidate.jd", -1]
+            - ["candidate.drb", -1]
+            - ["candid", -1]
           unique: false
         - name: jd_braai_magpsf_isdiffpos_ndethist
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "classifications.braai", 1 ]
-            - [ "candidate.magpsf", 1 ]
-            - [ "candidate.isdiffpos", 1 ]
-            - [ "candidate.ndethist", 1 ]
+            - ["candidate.jd", 1]
+            - ["classifications.braai", 1]
+            - ["candidate.magpsf", 1]
+            - ["candidate.isdiffpos", 1]
+            - ["candidate.ndethist", 1]
           unique: false
         - name: jd_field_drb_ndethhist_magpsf_isdiffpos_objectId
           fields:
-            - [ "candidate.jd", 1 ]
-            - [ "candidate.field", 1 ]
-            - [ "candidate.rb", 1 ]
-            - [ "candidate.drb", 1 ]
-            - [ "candidate.ndethist", 1 ]
-            - [ "candidate.magpsf", 1 ]
-            - [ "candidate.isdiffpos", 1 ]
-            - [ "objectId", -1 ]
+            - ["candidate.jd", 1]
+            - ["candidate.field", 1]
+            - ["candidate.rb", 1]
+            - ["candidate.drb", 1]
+            - ["candidate.ndethist", 1]
+            - ["candidate.magpsf", 1]
+            - ["candidate.isdiffpos", 1]
+            - ["objectId", -1]
           unique: false
 
       TNS:
         - name: radec__id
           fields:
-            - [ "coordinates.radec_geojson", "2dsphere" ]
-            - [ "_id", -1 ]
+            - ["coordinates.radec_geojson", "2dsphere"]
+            - ["_id", -1]
           unique: false
         - name: discovery_date
           fields:
-            - [ "discovery_date", -1 ]
+            - ["discovery_date", -1]
           unique: false
 
     filters:
       ZTF_alerts:
         # default upstream aggregation pipeline stages for filtering ZTF alerts:
-        - {"$match": {"candid": null, "candidate.programid": {"$in": null}}}
-        - {"$project": {"cutoutScience": 0, "cutoutTemplate": 0, "cutoutDifference": 0}}
-        - {"$lookup": {"from": "ZTF_alerts_aux", "localField": "objectId", "foreignField": "_id", "as": "aux"}}
-        - {"$project": {
-          "cross_matches": {
-            "$arrayElemAt": [
-              "$aux.cross_matches", 0
-            ]
-          },
-          "prv_candidates": {
-            "$filter": {
-              "input": {"$arrayElemAt": ["$aux.prv_candidates", 0]},
-              "as": "item",
-              "cond": {
-                "$and": [
-                  {"$in": ["$$item.programid", null]},
-                  {"$lt": [{"$subtract": ["$candidate.jd", "$$item.jd"]}, 100]}
-                ]
-              }
-            }
-          },
-          "schemavsn": 1,
-          "publisher": 1,
-          "objectId": 1,
-          "candid": 1,
-          "candidate": 1,
-          "classifications": 1,
-          "coordinates": 1
+        - {
+            "$match":
+              { "candid": null, "candidate.programid": { "$in": null } },
           }
-        }
+        - {
+            "$project":
+              {
+                "cutoutScience": 0,
+                "cutoutTemplate": 0,
+                "cutoutDifference": 0,
+              },
+          }
+        - {
+            "$lookup":
+              {
+                "from": "ZTF_alerts_aux",
+                "localField": "objectId",
+                "foreignField": "_id",
+                "as": "aux",
+              },
+          }
+        - {
+            "$project":
+              {
+                "cross_matches": { "$arrayElemAt": ["$aux.cross_matches", 0] },
+                "prv_candidates":
+                  {
+                    "$filter":
+                      {
+                        "input": { "$arrayElemAt": ["$aux.prv_candidates", 0] },
+                        "as": "item",
+                        "cond":
+                          {
+                            "$and":
+                              [
+                                { "$in": ["$$item.programid", null] },
+                                {
+                                  "$lt":
+                                    [
+                                      {
+                                        "$subtract":
+                                          ["$candidate.jd", "$$item.jd"],
+                                      },
+                                      100,
+                                    ],
+                                },
+                              ],
+                          },
+                      },
+                  },
+                "schemavsn": 1,
+                "publisher": 1,
+                "objectId": 1,
+                "candid": 1,
+                "candidate": 1,
+                "classifications": 1,
+                "coordinates": 1,
+              },
+          }
 
     xmatch:
       cone_search_radius: 2
@@ -209,17 +238,17 @@ kowalski:
         AllWISE:
           filter: {}
           projection:
-             _id: 1
-             coordinates.radec_str: 1
-             w1mpro: 1
-             w1sigmpro: 1
-             w2mpro: 1
-             w2sigmpro: 1
-             w3mpro: 1
-             w3sigmpro: 1
-             w4mpro: 1
-             w4sigmpro: 1
-             ph_qual: 1
+            _id: 1
+            coordinates.radec_str: 1
+            w1mpro: 1
+            w1sigmpro: 1
+            w2mpro: 1
+            w2sigmpro: 1
+            w3mpro: 1
+            w3sigmpro: 1
+            w4mpro: 1
+            w4sigmpro: 1
+            ph_qual: 1
 
         Gaia_DR2:
           filter: {}
@@ -254,19 +283,6 @@ kowalski:
             SDSS_name: 1
             Teff: 1
             eTeff: 1
-
-        PS1_STRM:
-          filter: {}
-          projection:
-            _id: 1
-            objID: 1
-            coordinates.radec_str: 1
-            class: 1
-            prob_Galaxy: 1
-            prob_Star: 1
-            prob_QSO: 1
-            z_phot: 1
-            z_phot_err: 1
 
         galaxy_redshifts_20200522:
           filter: {}
@@ -314,7 +330,20 @@ kowalski:
             snrz: 1
             objtype: 1
             class: 1
-            subclass:  1
+            subclass: 1
+
+        PS1_STRM:
+          filter: {}
+          projection:
+            _id: 1
+            objID: 1
+            coordinates.radec_str: 1
+            class: 1
+            prob_Galaxy: 1
+            prob_Star: 1
+            prob_QSO: 1
+            z_phot: 1
+            z_phot_err: 1
 
         PS1_DR1:
           filter: {}
@@ -334,7 +363,7 @@ kowalski:
 
   ml_models:
     braai:
-      version:  "d6_m9"
+      version: "d6_m9"
     acai_h:
       version: "d1_dnn_20201130"
     acai_v:
@@ -348,7 +377,7 @@ kowalski:
 
   skyportal:
     protocol: "http"
-    host: "skyportal_web_1"
+    host: "172.17.0.1"
     port: 5000
     username: "kowalski"
     token: "<token>"
@@ -364,9 +393,6 @@ kowalski:
     username: "username"
     password: "password"
 
-  tns:
-    url: https://wis-tns.org
-
   dask:
     host: 127.0.0.1
     scheduler_port: 8786
@@ -376,15 +402,17 @@ kowalski:
     lifetime_stagger: 1 hours
     lifetime_restart: true
 
+  tns:
+    url: https://wis-tns.org
+
   misc:
-    # working stand-alone or in conjunction with a SkyPortal instance?
-    broker: False
+    broker: True
     supported_penquins_versions: ["2.0.0", "2.0.1", "2.0.2", "2.1.0", "2.1.1"]
     query_expiration_interval: 5
     max_time_ms: 300000
     max_retries: 100
     logging_level: "debug"
-    openapi_validate:  False
+    openapi_validate: False
 
   # this is used to make supervisord.conf files at build time
   supervisord:
@@ -409,7 +437,7 @@ kowalski:
         serverurl: unix:///dev/shm/supervisor.sock
 
       "program:gunicorn":
-        # fixme: adjust number of workers -w for your system (e.g. -w 40 for kowalski.caltech.edu)
+        # fixme: adjust number of workers -w for your system
         command: >
           /usr/local/bin/gunicorn
           -w 2
@@ -437,7 +465,7 @@ kowalski:
       supervisord:
         logfile: /data/logs/supervisord.log
         logfile_maxbytes: 50MB
-        logfile_backups: 30
+        logfile_backups: 20
         loglevel: info
         pidfile: /tmp/supervisord.pid
         nodaemon: True

--- a/docker-compose.traefik.defaults.yaml
+++ b/docker-compose.traefik.defaults.yaml
@@ -1,115 +1,36 @@
 version: "3.7"
 
-volumes:
-  mongodb:
-  data:
+networks:
+  default:
+    external:
+      name: fritz_net
 
 services:
-
   traefik:
-    image: "traefik:2.1"
+    image: "traefik:v2.2"
     container_name: "traefik"
     command:
-      # fixme: comment out if do not want the traefik dashboard on port 8081
+      # fixme: comment out if do not want the traefik dashboard on port 8090
       - "--api.insecure=true"
+      - "--metrics=true"
+      - "--metrics.prometheus=true"
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=proxy"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
-      # Enable a http challenge named "myhttpchallenge"
-      - "--certificatesresolvers.myhttpchallenge.acme.httpchallenge=true"
-      # Tell it to use our predefined entrypoint named "web"
-      - "--certificatesresolvers.myhttpchallenge.acme.httpchallenge.entrypoint=web"
-      # The email to provide to let's encrypt
-      - "--certificatesresolvers.myhttpchallenge.acme.email=kowalski@caltech.edu"
-      # Tell to store the certificate on a path under our volume
-      - "--certificatesresolvers.myhttpchallenge.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.myresolver.acme.httpchallenge=true"
+      - "--certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=web"
+      #- "--certificatesresolvers.myresolver.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+      - "--certificatesresolvers.myresolver.acme.email=private@caltech.edu"
+      - "--certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json"
+
     ports:
       - "80:80"
       - "443:443"
       # fixme: traefik dashboard
-      - "8081:8080"
+      - "8090:8080"
     volumes:
       # Create a letsencrypt dir within the folder where the docker-compose file is
       - "./letsencrypt:/letsencrypt"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-
-  api:
-    build:
-      context: .
-      dockerfile: api.Dockerfile
-    #    entrypoint: python -m pytest -s test_api.py
-    image: dmitryduev/kowalski_api:latest
-    volumes:
-      - data:/data
-    expose:
-      - "4000"
-    # fixme: comment out ports if deploying behind traefik
-#    ports:
-#      - "4000:4000"
-    labels:
-      # middleware redirect
-      - "traefik.http.middlewares.https_redirect.redirectscheme.scheme=https"
-      - "traefik.http.middlewares.https_redirect.redirectscheme.permanent=true"
-      # global redirect to https
-      - "traefik.http.routers.http_catchall.rule=hostregexp(`{host:.+}`)"
-      - "traefik.http.routers.http_catchall.entrypoints=web"
-      - "traefik.http.routers.http_catchall.middlewares=https_redirect"
-      # Explicitly tell Traefik to expose this container
-      - "traefik.enable=true"
-      # The domain the service will respond to
-      - "traefik.http.routers.kowalski.rule=Host(`private.caltech.edu`)"
-      - "traefik.http.services.kowalski.loadbalancer.server.port=4000"
-      # Allow request only from the predefined entry point named "websecure"
-      - "traefik.http.routers.kowalski.entrypoints=websecure"
-      # Uses the Host rule to define which certificate to issue
-      - "traefik.http.routers.kowalski.tls.certresolver=myhttpchallenge"
-    links:
-      - mongo:kowalski-mongo
-    restart: always
-    depends_on:
-      - mongo
-
-  ingester:
-    build:
-      context: .
-      dockerfile: ingester.Dockerfile
-    image: dmitryduev/kowalski_ingester:latest
-    ports:
-      - "8787:8787"
-    volumes:
-      - data:/data
-    links:
-      - mongo:kowalski-mongo
-    restart: always
-    depends_on:
-      - mongo
-
-  mongo:
-#    image: mongo:latest
-    build:
-      context: .
-      dockerfile: mongo.Dockerfile
-    hostname: mongo
-    expose:
-      - "27017"
-    # fixme:
-    ports:
-      - "27017:27017"
-    depends_on:
-      - traefik
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=mongoadmin
-      - MONGO_INITDB_ROOT_PASSWORD=mongoadminsecret
-      - MONGO_REPLICA_SET_NAME=rs0
-    volumes:
-      - mongodb:/data/db
-    restart: always
-    networks:
-      - kowalski
-    healthcheck:
-      test: test $$(echo "rs.initiate().ok || rs.status().ok" | mongo -u $${MONGO_INITDB_ROOT_USERNAME} -p $${MONGO_INITDB_ROOT_PASSWORD} --quiet) -eq 1
-      interval: 10s
-      start_period: 20s
-    # run as a replica set of size 1 called rs0 using keyfile for internal authorization
-    command: [ "--keyFile", "/opt/keyfile", "--replSet", "rs0", "--bind_ip_all" ]


### PR DESCRIPTION
This PR moves the kowalski extensions and configuration that lived in the toplevel `fritz` directory to `kowalski/`. 

